### PR TITLE
Replaced thenewboston-python repo link in requirements

### DIFF
--- a/requirements/local.in
+++ b/requirements/local.in
@@ -1,2 +1,2 @@
 -r base.in
--e git+ssh://git@github.com/thenewboston-developers/thenewboston-python.git#egg=thenewboston
+-e git+https://github.com/thenewboston-developers/thenewboston-python.git#egg=thenewboston

--- a/requirements/local.in
+++ b/requirements/local.in
@@ -1,2 +1,1 @@
 -r base.in
--e git+https://github.com/thenewboston-developers/thenewboston-python.git#egg=thenewboston

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/local.txt requirements/local.in
 #
--e git+ssh://git@github.com/thenewboston-developers/thenewboston-python.git#egg=thenewboston  # via -r requirements/local.in
+-e git+https://github.com/thenewboston-developers/thenewboston-python.git#egg=thenewboston  # via -r requirements/local.in
 amqp==2.6.0               # via kombu
 asgiref==3.2.10           # via django
 billiard==3.6.3.0         # via celery

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/local.txt requirements/local.in
 #
--e git+https://github.com/thenewboston-developers/thenewboston-python.git#egg=thenewboston  # via -r requirements/local.in
+thenewboston==0.0.1       # via pypi
 amqp==2.6.0               # via kombu
 asgiref==3.2.10           # via django
 billiard==3.6.3.0         # via celery


### PR DESCRIPTION
I've replaced the repository links in requirements /local.in & requirements /local.txt to make it easier to clone the repo when installing the requirements without adding the SSH key on GitHub.

I've tested the change, it works fine.