### PR TITLE
Review

### DIFF
--- a/v1/conftest.py
+++ b/v1/conftest.py
@@ -25,11 +25,12 @@ def client():
 
 
 @pytest.fixture
-def confirmation_validator_configuration():
+def confirmation_validator_configuration(monkeypatch):
     call_command(
         'initialize_test_confirmation_validator',
         ip='127.0.0.1'
     )
+    monkeypatch.setenv('NETWORK_SIGNING_KEY', '7a3359729b41f953d52818e787a312c8576e179e2ee50a2e4f28c4596b12dce0')
     yield get_self_configuration(exception_class=RuntimeError)
 
 
@@ -44,11 +45,12 @@ def encoded_account_number(account_number):
 
 
 @pytest.fixture
-def primary_validator_configuration():
+def primary_validator_configuration(monkeypatch):
     call_command(
         'initialize_test_primary_validator',
         ip='127.0.0.1'
     )
+    monkeypatch.setenv('NETWORK_SIGNING_KEY', '6f812a35643b55a77f71c3b722504fbc5918e83ec72965f7fd33865ed0be8f81')
     yield get_self_configuration(exception_class=RuntimeError)
 
 

--- a/v1/decorators/nodes.py
+++ b/v1/decorators/nodes.py
@@ -20,7 +20,7 @@ def is_self_signed_message(func):
     """
 
     @wraps(func)
-    def inner(object, request, *args, **kwargs):
+    def inner(obj, request, *args, **kwargs):
         request, error = verify_request_signature(request=request, signed_data_key='message')
 
         if error:
@@ -32,7 +32,7 @@ def is_self_signed_message(func):
         if node_identifier != self_configuration.node_identifier:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
 
-        return func(object, request, *args, **kwargs)
+        return func(obj, request, *args, **kwargs)
 
     return inner
 


### PR DESCRIPTION
- added `monkeypatch.setenv()` for the `NETWORK_SIGNING_KEY` since `get_signing_key()` was returning the environment variable from the actual OS
- renamed `object` to `obj` to avoid using built-in name

<img width="492" alt="Screen Shot 2020-08-16 at 11 35 45 AM" src="https://user-images.githubusercontent.com/8547538/90341476-d3dffa80-dfb4-11ea-839f-a3a756ad6247.png">
