### PR TITLE
Root account file url is not validated when an error occur

### DIFF
--- a/v1/self_configurations/management/commands/initialize_validator.py
+++ b/v1/self_configurations/management/commands/initialize_validator.py
@@ -137,6 +137,7 @@ class Command(InitializeNode):
                 logger.exception(e)
                 self.stdout.write(self.style.ERROR(f'Error downloading {root_account_file}'))
                 self.stdout.write(self.style.ERROR(e))
+                continue
 
             file_hash = get_file_hash(settings.ROOT_ACCOUNT_FILE_PATH)
 


### PR DESCRIPTION
Previously, when an error occured during the downloading of the root account file, the link was validated.
Now it will keep asking for a valid url.

--
#aaf42054f84c66586bf29d446188347ab910112cb60b775a4d6feadd5b9ae73f